### PR TITLE
Set install name to full install path by default on macOS, closes #4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ set(LIB_VERSION_STRING ${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_P
 
 set(VERSION "v${LIB_VERSION_STRING}")
 
+if(APPLE AND NOT CMAKE_INSTALL_NAME_DIR)
+  set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
+endif()
+
 #set(HEADERS fparser.hh fpconfig.hh fptypes.hh)
 set(SOURCES fparser.cc fpoptimizer.cc)
 


### PR DESCRIPTION
On macOS, running a build of openEMS installed to a custom location will fail. The RPATH for the custom location is not set correctly, only system directories are searched, as a result, fparser cannot be found (Bug #4).

    $ ~/opt/bin/openEMS
    dyld[90539]: Library not loaded: libfparser.4.dylib

Curiously, only fparser is affected, other libraries such as CSXCAD is not.

After some investigation, I found the root cause is that the "install name" of `libfparser` does not contain a full path, but CSXCAD's "install name" is an absolute path. Thus, CSXCAD can be found correctly using the absolute install path, but `libfparser` cannot. After CSXCAD and openEMS are built, this incomplete install name will propagate upwards, so all binaries will have a wrong search path for `libfparser`.

    $ otool -D ~/opt/lib/libCSXCAD.dylib
    /Users/gentoo/opt/lib/libCSXCAD.dylib:
    /Users/gentoo/opt/lib/libCSXCAD.0.dylib

    $ otool -D ~/opt/lib/libfparser.4.5.1.dylib
    /Users/gentoo/opt/lib/libfparser.4.5.1.dylib:
    libfparser.4.dylib

This commits set the install name of fparser to its full install path by default on macOS, so it behaves consistently to libCSXCAD.