### PR TITLE
CMakeLists.txt: use 3.0...3.10 as minimum version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ SET( CMAKE_BUILD_TYPE Release )
 
 PROJECT(fparser CXX)
 
-cmake_minimum_required(VERSION 2.8)
+# In CMake 4, 3.10 is deprecated and 3.5 has been removed.
+# use 3.0...3.10 so all of these versions are acceptable as min. version.
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+cmake_minimum_required(VERSION 3.0...3.10)
 
 # default
 set(LIB_VERSION_MAJOR 4)


### PR DESCRIPTION
In CMake 4, 3.10 is deprecated and 3.5 has been removed. Use 3.0...3.10 so all of these versions are acceptable as minimum version. Also, openEMS already requires CMake 3, so drop support of obsolete CMake 2.8 (which is not even documented anymore).

This fixes build on macOS, and potentially other systems in the future.

See: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html