### PR TITLE
Disable or Fix Several Compiler and CMake Warnings, add CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,244 @@
+name: "CI"
+
+on:
+  push:
+    branches:
+        - '**'
+  pull_request:
+    branches:
+        - '**'
+
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      # Use "false" means a single failed build won't terminate other combinations
+      # in the matrix. This wastes CPU time, but is an important debugging tool to
+      # prevent a single broken platform from stopping the whole matrix.
+      fail-fast: false
+
+      matrix:
+        os:
+          # name: OS name (only a name for humans to read).
+          # libc: userland libc, "GNU" or "musl"
+          #       (only a name for humans to read)
+          # ancient: true or false.
+          #          true: incompatible with GitHub's actions/checkout due to
+          #                node.js compatibility problem. Manual git checkout
+          #                required.
+          #          false: use standard GitHub's actions/checkout.
+          # docker-image: string, image on DockerHub to use
+          - name: "CentOS 7"
+            libc: "GNU"
+            ancient: true
+            docker-image: "centos:7"
+
+          - name: "Ubuntu 14.04"
+            libc: "GNU"
+            ancient: true
+            docker-image: "ubuntu:14.04"
+
+          - name: "Debian oldoldstable"
+            libc: "GNU"
+            ancient: false
+            docker-image: "debian:oldoldstable"
+
+          - name: "Debian oldstable"
+            libc: "GNU"
+            ancient: false
+            docker-image: "debian:oldstable"
+
+          - name: "Debian"
+            libc: "GNU"
+            ancient: false
+            docker-image: "debian:latest"
+
+          - name: "Ubuntu"
+            libc: "GNU"
+            ancient: false
+            docker-image: "ubuntu:latest"
+
+          - name: "Fedora"
+            libc: "GNU"
+            ancient: false
+            docker-image: "fedora:latest"
+
+          - name: "AlmaLinux 8"
+            libc: "GNU"
+            ancient: false
+            docker-image: "almalinux:8"
+
+          - name: "AlmaLinux Latest"
+            libc: "GNU"
+            ancient: false
+            docker-image: "almalinux:latest"
+
+          - name: "Alpine"
+            libc: "musl"
+            ancient: false
+            docker-image: "alpine:latest"
+
+    container:
+      image: ${{ matrix.os.docker-image }}
+
+    name: "${{ matrix.os.libc }}/Linux (${{ matrix.os.name }})"
+
+    steps:
+      - name: Check for dockerenv file
+        # bash is not installed on Alpine at this point
+        shell: sh
+        run: (ls /.dockerenv && echo Found dockerenv) || exit 1
+
+      - name: Install dependencies
+        shell: sh
+        run: |
+          touch ~/.bash_profile  # set environmental variables here
+          echo 'export CXXFLAGS="-Wall -Wextra -Wno-error"' >> ~/.bash_profile
+
+          if grep -q "ID=fedora" /etc/os-release; then
+            dnf install -y gcc gcc-c++ cmake
+          elif grep -q 'ID="almalinux"' /etc/os-release; then
+            dnf install -y epel-release
+            dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb
+
+            dnf install -y gcc gcc-c++ cmake
+          elif grep -q "ID=debian" /etc/os-release || grep -q "ID=ubuntu" /etc/os-release; then
+            # retry failed downloads 3 times
+            echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+            apt-get update
+            apt-get install -y build-essential
+
+            if grep -q 'VERSION_ID="14.04"' /etc/os-release; then
+              # Ubuntu 14.04 is incompatible with actions/checkout@v4
+              apt-get install -y git
+
+              # Ubuntu 14.04 has CMake 2 by default, but we require CMake 3
+              apt-get install -y cmake3
+            else
+              apt-get install -y cmake
+            fi
+          elif grep -q "ID=alpine" /etc/os-release; then
+            apk add bash build-base cmake
+          elif [ -f /etc/centos-release ]; then
+            # IPv6 on GitHub Actions is broken, causing random network failures
+            # if a CDN rosolves to IPv6.
+            echo "ip_resolve=4" >> /etc/yum.conf
+
+            # CentOS repos are EOL and desupported
+            sed -i 's|^mirrorlist|#mirrorlist|g; s|^#baseurl|baseurl|g; s|mirror.centos.org|vault.centos.org|g' \
+                /etc/yum.repos.d/CentOS-Base.repo
+
+            yum install -y centos-release-scl || true
+            sed -i 's|^mirrorlist|#mirrorlist|g; s|^#baseurl|baseurl|g;
+                    s|^# baseurl|baseurl|g; s|mirror.centos.org|vault.centos.org|g' \
+                /etc/yum.repos.d/CentOS-SCLo-scl.repo \
+                /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+            cat /etc/yum.repos.d/CentOS-SCLo-scl.repo
+            cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+
+            yum install -y epel-release
+            yum install -y git
+            yum install -y gcc gcc-c++ \
+                           make cmake3
+
+            # use cmake3 instead of default cmake2
+            alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 99
+          else
+            echo "Unknown system!"
+            exit 1
+          fi
+
+      - if: ${{ ! matrix.os.ancient }}
+        name: Checkout fparser.git
+        uses: actions/checkout@v4
+        with:
+          path: fparser
+
+      - if: ${{ matrix.os.ancient }}
+        name: Checkout fparser.git (legacy system only)
+        run: |
+          echo "Clone $GITHUB_SHA from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git fparser
+          cd $GITHUB_WORKSPACE/fparser
+
+          git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/pull/*/merge:refs/remotes/origin/pr/*"
+          git checkout $GITHUB_SHA
+
+      - name: Build and install fparser
+        run: |
+          source ~/.bash_profile
+          cd $GITHUB_WORKSPACE/fparser
+          mkdir build && cd build
+          cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
+          make -j`nproc` && make install
+
+  macOS:
+    name: "macOS (ARM, latest)"
+
+    runs-on: macos-latest
+    steps:
+      - name: Install dependencies
+        shell: sh
+        run: |
+          echo "export NCPUS=$(sysctl -n hw.ncpu)" >> ~/.zprofile
+          echo 'export CXXFLAGS="-Wall -Wextra -Wno-error"' >> ~/.zprofile
+          brew install cmake
+
+      - name: Checkout fparser.git
+        uses: actions/checkout@v4
+
+      - name: Build and install fparser
+        run: |
+          source ~/.zprofile
+          mkdir build && cd build
+          cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
+          make -j$NCPUS && make install
+
+  FreeBSD:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        machine:
+          - name: "FreeBSD 14.2"
+            os: freebsd
+            arch: x86-64
+            version: '14.2'
+
+          # macOS already tests ARM for us, so disable the slow ARM emulator
+          # for now
+          #- name: "FreeBSD 14.2 (ARM emulator)"
+          #  os: freebsd
+          #  arch: arm64
+          #  version: '14.2'
+
+    name: "${{ matrix.machine.name }}"
+
+    steps:
+      - name: Checkout fparser.git
+        uses: actions/checkout@v4
+
+      - name: Test in FreeBSD ${{ matrix.machine.version }} ${{ matrix.machine.arch }}
+        uses: cross-platform-actions/action@v0.26.0
+        with:
+          cpu_count: 4
+          architecture: ${{ matrix.machine.arch }}
+          operating_system: ${{ matrix.machine.os }}
+          version: ${{ matrix.machine.version }}
+          sync_files: runner-to-vm
+          run: |
+            echo "Install dependencies..."
+            sudo pkg install -y cmake
+
+            export NCPUS=$(sysctl -n hw.ncpu)
+            export CXXFLAGS="-Wall -Wextra -Wno-error"
+
+            echo "Build and install fparser..."
+            mkdir build && cd build
+            cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
+            make -j$NCPUS && make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@
 # define build type
 SET( CMAKE_BUILD_TYPE Release )
 
-PROJECT(fparser CXX)
-
 # In CMake 4, 3.10 is deprecated and 3.5 has been removed.
 # use 3.0...3.10 so all of these versions are acceptable as min. version.
 # https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
 cmake_minimum_required(VERSION 3.0...3.10)
+
+PROJECT(fparser CXX)
 
 # default
 set(LIB_VERSION_MAJOR 4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,31 @@
+# Currently, GCC generates a massive warning with over 60 lines
+# for a single class, the last few lines are:
+# 
+#     fpoptimizer.cc:768:13: warning: implicitly-declared
+#     ‘FPoptimizer_Optimize::MatchInfo<double>::MatchInfo(const
+#     FPoptimizer_Optimize::MatchInfo<double>&)’ is deprecated
+#     [-Wdeprecated-copy]
+#       768 | #define yD1 AnyParams_Rec
+#           |             ^~~~~~~~~~~~~
+# 
+# This is a legitimate warning about the potential removal of a
+# deprecated default behavior by future C++ versions.
+# 
+# Since fparser is already a legacy project, and the problem exists
+# in auto-generates code, fixing it is a very-low priority task. For
+# now, restrict ourselves to C++98 only, removing the warning and
+# ensuring its behavior won't change for any future compiler.
+# Optionally, fparser has C++11 features controlled via
+# FP_SUPPORT_CPLUSPLUS11_MATH_FUNCS, but none is enabled in this fork.
+set(CMAKE_CXX_STANDARD 98)
 
 # define build type
 SET( CMAKE_BUILD_TYPE Release )
 
 # In CMake 4, 3.10 is deprecated and 3.5 has been removed.
-# use 3.0...3.10 so all of these versions are acceptable as min. version.
+# use 3.1...3.10 so all of these versions are acceptable as min. version.
 # https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
-cmake_minimum_required(VERSION 3.0...3.10)
+cmake_minimum_required(VERSION 3.1...3.10)
 
 PROJECT(fparser CXX)
 

--- a/fpconfig.hh
+++ b/fpconfig.hh
@@ -8,6 +8,13 @@
 |* (See lgpl.txt and gpl.txt for the license text.)                        *|
 \***************************************************************************/
 
+// Auto-generated code in fpoptimizer.cc and extrasrc/ raise
+// hundreds of warnings.
+#if defined(__GNUC__) && __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#endif
+
 // Configuration file
 // ------------------
 


### PR DESCRIPTION
## Introduction

A constant flood of warnings is harmful, even if the warnings are safe to ignore, because they would mask useful warnings in the future. This Pull Request fix, disable or workaround several warnings in `fparser`.

## Warning Fixes

### fpconfig.hh: disable -Wimplicit-fallthrough and -Wmisleading-indentation
    
Currently, compiling fparser generates hundreds of compiler warnings, over 99% of them are fallthrough and indentation warnings of auto-generated code in `extrasrc/` and `fpoptimizer.hh`.
    
Since the code is auto-generated, there's nothing we can do about it, and they mask real warnings. Disable them.

### CMakeLists.txt: move CMAKE_MINIMUM_REQUIRED above PROJECT
    
    CMake Warning (dev) at CMakeLists.txt:5 (PROJECT):
    cmake_minimum_required() should be called prior to this top-level project()
    call.

### CMakeLists.txt: set(CMAKE_CXX_STANDARD 98).
    
Currently, GCC generates a massive warning with over 60 lines for a single class, the last few lines are:
    
        fpoptimizer.cc:768:13: warning: implicitly-declared
        ‘FPoptimizer_Optimize::MatchInfo<double>::MatchInfo(const
        FPoptimizer_Optimize::MatchInfo<double>&)’ is deprecated
        [-Wdeprecated-copy]
          768 | #define yD1 AnyParams_Rec
              |             ^~~~~~~~~~~~~
    
This is a legitimate warning about the potential removal of a deprecated default behavior by future C++ versions.
    
Since fparser is already a legacy project, and the problem exists in auto-generates code, it's unlikely to be fixed any time soon, fixing it would be a very-low priority task for openEMS. For now, we simply use `set(CMAKE_CXX_STANDARD 98)` in `CMakeFiles.txt` to restrict ourselves to C++98 only, removing the warning and ensuring its behavior won't change for any future compiler. Optionally, fparser has C++11 features, but none is currently by default.
    
Note that the flag `CMAKE_CXX_STANDARD` is introduced in CMake 3.1, not CMake 3.0, we bump the minimum CMake version accordingly. Since CMake 3.5 is available even on Ubuntu 14.04, compatibility issues are unlikely.

## CI/CD

The commits above change CMake and compiler flags, and history tells us that no matter how trivial, unanticipated problems could arise. We also add full-scale CI/CD to this subproject (simplified version from the main project), just to be sure.

### CI: Add GitHub Actions for Continuous Integration
    
This commit introduces Continuous Integration via GitHub Actions on multiple operating systems, including Debian, Debian oldstable, Debian oldoldstable, Fedora, AlmaLinux 8, AlmaLinux 9, and macOS on ARM. To ensure POSIX compatibility, Alpine Linux is tested due to its non-GNU C library, and FreeBSD is tested due to its non-Linux environment. For legacy compatibility, Ubuntu 14.04 and CentOS 7 is also tested.