### PR TITLE
Windows MSVC/clang-cl Test using Visual Studio 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,10 @@ name: "CI"
 
 on:
   push:
-    branches:
-        - '**'
+    branches: ["**"]
+
   pull_request:
-    branches:
-        - '**'
+    branches: ["**"]
 
 jobs:
   Linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,3 +242,58 @@ jobs:
             mkdir build && cd build
             cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
             make -j$NCPUS && make install
+
+  Windows:
+    runs-on: windows-latest
+
+    strategy:
+      # Use "false" means a single failed build won't terminate other combinations
+      # in the matrix. This wastes CPU time, but is an important debugging tool to
+      # prevent a single broken platform from stopping the whole matrix.
+      fail-fast: false
+
+      matrix:
+        toolchain:
+          # name: toonchain name (only a name for humans to read).
+          # CC, CXX: C/C++ compiler, environment variables
+          # CFLAGS, CXXFLAGS: C/C++ flags, environment variables
+          - name: "MSVC"
+            CC: "cl"
+            CXX: "cl"
+
+          - name: "clang-cl"
+            CC: "clang-cl"
+            CXX: "clang-cl"
+
+    env:
+      VS_ROOT_DIR: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/"
+      CC: "${{ matrix.toolchain.CC }}"
+      CXX: "${{ matrix.toolchain.CXX }}"
+      CFLAGS: "/D_WIN32_WINNT=0x0601"
+      CXXFLAGS: "/D_WIN32_WINNT=0x0601"
+
+    name: "Windows (${{ matrix.toolchain.name }}, latest)"
+
+    steps:
+      - name: Checkout fparser.git
+        uses: actions/checkout@v4
+
+      # It doesn't really work, because MSVC itself doesn't support long path.
+      # But for future-proofing (it does work for clang).
+      - name: Enable Long Paths
+        run: |
+          New-ItemProperty -Path "HKLM:/SYSTEM/CurrentControlSet/Control/FileSystem" `
+                           -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
+      - name: Build and install fparser
+        run: |
+          & "$env:VS_ROOT_DIR/Common7/Tools/Launch-VsDevShell.ps1" -Arch amd64 -HostArch amd64
+
+          cd "$env:GITHUB_WORKSPACE"
+          mkdir build && cd build
+          cmake ../ -GNinja -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON `
+                    -DCMAKE_BUILD_TYPE=Release `
+                    -DCMAKE_INSTALL_PREFIX="$HOME/opt"
+
+          cmake --build ./ --parallel
+          cmake --install ./ --parallel 8


### PR DESCRIPTION
This commit introduces Continuous Integration for Windows with MSVC/clang-cl shipped in Visual Studio 2022.
